### PR TITLE
fix function call (missing a comma)

### DIFF
--- a/app/views/gallery/_slideshow.html.haml
+++ b/app/views/gallery/_slideshow.html.haml
@@ -13,7 +13,7 @@
     .msg_thumb_wrapper      
       - photos.page(:first).photos.each do |photo|
         %a{href: "#"}
-          = gallery_image :slideshow photo
+          = gallery_image :slideshow, photo
     - photos.pages.remainder.each do |page|
       .msg_thumb_wrapper{style: 'display:none'}
         - page.photos.each do |photo|


### PR DESCRIPTION
I found another issue, when ussing the slideshow gallery an error was raised cause we are missing a comma when calling a function.

I will try to fix the other issue with the responsive gallery ;)
